### PR TITLE
fix: use pure-python protobuf implementation

### DIFF
--- a/docker-compose.yml.template
+++ b/docker-compose.yml.template
@@ -26,6 +26,7 @@ services:
         - WORKERS=kernelci:pass
         - BUILDBOT_STATUS_TOKEN=gentoo_webhook
         - TCP_PORTS=8010,9989
+        - PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python
     depends_on:
       - db
     links:
@@ -63,6 +64,7 @@ services:
         WORKERNAME: worker_name
         WORKERPASS: worker_pass
         WORKER_ENVIRONMENT_BLACKLIST: DOCKER_BUILDBOT* BUILDBOT_ENV_* BUILDBOT_1* WORKER_ENVIRONMENT_BLACKLIST
+        PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION: python
     volumes:
       - fileserver:/var/www/fileserver
       - worker_data:/buildbot


### PR DESCRIPTION
closes https://github.com/GKernelCI/GKCI-main/issues/27

I learned recently that the connection to KCIDB has been broken, and in the error message, one of their methods of fixing this error was to set `PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python`.